### PR TITLE
use NODE_CONFIG_ENV to determine config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ $ NODE_ENV=production node app
 
 When starting an application in this way `exp-config` will instead load `<app_root>/config/production.json`. Likewise, it's common to have a separate configuration file for tests, and use `NODE_ENV=test` when running them.
 
+### NODE_CONFIG_ENV
+
+In some cases you want or need to use `NODE_ENV=production` to get for instance performance benfits in [Express.js](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production). But we still want load specific configuration for an evironment you can use `NODE_CONFIG_ENV` to use for configuration identification.
+
+```
+NODE_ENV=production NODE_CONFIG_ENV=qa node app
+```
+
+The `qa` configuration would be used instead of the `production` configuration.
+
 ## Overriding configuration values
 
 Individual values in the loaded configuration can be overridden by placing a file named `.env` in the application's root (`<app_root>/.env`). An example `.env` file can look like this:

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const path = require("path");
 const dotenv = require("dotenv");
 const merge = require("lodash.merge");
 
-const envName = process.env.NODE_ENV || "development";
+const envName = process.env.NODE_CONFIG_ENV || process.env.NODE_ENV || "development";
 const basePath = process.env.CONFIG_BASE_PATH || process.cwd();
 const prefix = process.env.ENV_PREFIX;
 const charToConvert = process.env.INTERPRET_CHAR_AS_DOT;

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,14 @@ describe("config", () => {
     delete process.env.NODE_ENV;
   });
 
+  it("retrives values from JSON files specified in the NODE_CONFIG_ENV environment variable", () => {
+    process.env.NODE_ENV = "development";
+    process.env.NODE_CONFIG_ENV = "test";
+    require("../index").should.have.property("prop").equal("from test");
+    delete process.env.NODE_ENV;
+    delete process.env.NODE_CONFIG_ENV;
+  });
+
   it("retrives values from JSON files from <app root>/config", () => {
     require("../tmp/index").should.have.property("prop").equal("value");
   });


### PR DESCRIPTION
I some cases you want to run with `NODE_ENV=production` to get performance benefits https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production. Or the case we hit was when running a Next.js application in a docker container and we need NODE_ENV to be set to production to start the application.