### PR TITLE
properly name the declared module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-declare module 'config';
+declare module 'exp-config';


### PR DESCRIPTION
The name of the typescript module makes the index.d.ts unusable. You get TS2306 when trying to use it in a typescript project.